### PR TITLE
RepeatRunner 개발 

### DIFF
--- a/src/test/java/com/naver2021test/runner/RepeatRunner.java
+++ b/src/test/java/com/naver2021test/runner/RepeatRunner.java
@@ -1,0 +1,130 @@
+package com.naver2021test.runner;
+
+import com.naver2021test.utils.AnnotationUtils;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.Runner;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.Suite;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.TestClass;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * {@link Repeat} annotation을 확인하여 메소드 반복실행을 처리할 {@link Runner} 구현체
+ * 테스트 결과를 메소드 별로 그룹화 하여 보여주기 위해 {@link RepeatMethodGroupingRunner}로 구성하여 처리한다.
+ *
+ * @author M.Ryan (sh.ryan.park@dreamus.io)
+ * @since 2021-05-04
+ */
+public class RepeatRunner extends Suite {
+	
+	private final ArrayList<Runner> runners = new ArrayList<>();
+	
+	public RepeatRunner(Class<?> testClass) throws InitializationError {
+		super(testClass, Collections.emptyList());
+		
+		for (final FrameworkMethod method : getTestClass().getAnnotatedMethods(Test.class)) {
+			if (method.getAnnotation(Ignore.class) != null) {
+				continue;
+			}
+			
+			if (AnnotationUtils.findAnnotation(method.getMethod(), Repeat.class).isPresent()) {
+				runners.add(new RepeatMethodGroupingRunner(getTestClass(), method));
+			} else {
+				runners.add(new SimpleMethodRunner(method, getTestClass()));
+			}
+		}
+	}
+	
+	@Override
+	protected List<Runner> getChildren() {
+		return this.runners;
+	}
+	
+	/**
+	 * {@link FrameworkMethod}를 입력받아 동작하는 {@link BlockJUnit4ClassRunner}
+	 * 반복 처리를 위해 입력받은 {@link FrameworkMethod}를 {@link FrameworkMethodWithIndexed}로 복사하여 {@code duplicateIndexedChildren}에 저장한다.
+	 */
+	public static class RepeatMethodGroupingRunner extends BlockJUnit4ClassRunner {
+		
+		private final FrameworkMethod parent;
+		private final ArrayList<FrameworkMethod> duplicateIndexedChildren = new ArrayList<>();
+		
+		protected RepeatMethodGroupingRunner(TestClass testClass, FrameworkMethod parent) throws InitializationError {
+			super(testClass);
+			this.parent = parent;
+			
+			final int repeatCount = AnnotationUtils.getRepeatCount(parent.getMethod());
+			if (repeatCount > 1) {
+				for (int i = 0; i < AnnotationUtils.getRepeatCount(parent.getMethod()); i++) {
+					duplicateIndexedChildren.add(new FrameworkMethodWithIndexed(parent.getMethod(), i));
+				}
+			}
+		}
+		
+		@Override
+		protected String testName(FrameworkMethod method) {
+			return indexedTestName(method);
+		}
+		
+		@Override
+		protected List<FrameworkMethod> getChildren() {
+			return duplicateIndexedChildren;
+		}
+		
+		/**
+		 * method 명으로 grouping 하여 보여줄 수 있게 {@code getName}을 parent의 메소드 명을 반환하도록 override 한다
+		 */
+		@Override
+		protected String getName() {
+			return parent.getName();
+		}
+		
+		private static String indexedTestName(FrameworkMethod method) {
+			if (method instanceof FrameworkMethodWithIndexed) {
+				return ((FrameworkMethodWithIndexed) method).getIndexedName();
+			} else {
+				return method.getName();
+			}
+		}
+	}
+	
+	/**
+	 * {@link Repeat} 에 의해 반복될 경우 해당 {@link FrameworkMethod}의 반복 index를 가질 수 있게 확장한 class
+	 */
+	static class FrameworkMethodWithIndexed extends FrameworkMethod {
+		private final Integer index;
+		
+		public FrameworkMethodWithIndexed(Method method, int index) {
+			super(method);
+			this.index = index;
+		}
+		
+		@Override
+		public String getName() {
+			return super.getName();
+		}
+		
+		public String getIndexedName() {
+			return String.format("%s[%s]", getMethod().getName(), index);
+		}
+		
+		/**
+		 * {@code BlockJUnit4ClassRunner.describeChild}는 동일한 {@link FrameworkMethod}일 경우 {@code methodDescriptions} map에
+		 * {@link Description}을 저장하고 재사용한다. 이 때 key값이 되는 hasCode는 생성자로 입력 받은 {@code method}의 hasCode이므로,
+		 * {@link FrameworkMethodWithIndexed}를 생성할 때 동일한 method를 반복하여 사용하므로 hasCode를 바꿔주지 않으면
+		 * {@link Description} 재사용 되어 0번 index만 찍히는 문제가 발생하므로 {@code hashCode}를 override 하여 모든 index에 대하여 표시할 수 있게 한다.
+		 */
+		@Override
+		public int hashCode() {
+			return super.hashCode() + index;
+		}
+	}
+}

--- a/src/test/java/com/naver2021test/runner/SimpleMethodRunner.java
+++ b/src/test/java/com/naver2021test/runner/SimpleMethodRunner.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2019 DREAMUS COMPANY.
+ * All right reserved.
+ * This software is the confidential and proprietary information of DREAMUS COMPANY.
+ * You shall not disclose such Confidential Information and
+ * shall use it only in accordance with the terms of the license agreement
+ * you entered into with DREAMUS COMPANY.
+ */
+
+package com.naver2021test.runner;
+
+import org.junit.internal.AssumptionViolatedException;
+import org.junit.internal.runners.model.EachTestNotifier;
+import org.junit.runner.Description;
+import org.junit.runner.Runner;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.TestClass;
+
+/**
+ * {@link org.junit.runners.BlockJUnit4ClassRunner}과 동일하게 {@link TestMethodBlock}을
+ * 구축해서 {@code Before}, {@code After} 등도 제대로 동작할 수 있게 구성해준다.
+ *
+ * @author M.Ryan (sh.ryan.park@dreamus.io)
+ * @since 2021-05-04
+ */
+class SimpleMethodRunner extends Runner {
+	final FrameworkMethod method;
+	final TestClass testClass;
+	
+	public SimpleMethodRunner(FrameworkMethod method, TestClass testClass) {
+		this.method = method;
+		this.testClass = testClass;
+	}
+	
+	@Override
+	public Description getDescription() {
+		return newDescription(method, testClass);
+	}
+	
+	@Override
+	public void run(RunNotifier notifier) {
+		final Description description = getDescription();
+		final EachTestNotifier eachNotifier = new EachTestNotifier(notifier, description);
+		eachNotifier.fireTestStarted();
+		try {
+			new TestMethodBlock(testClass, method).evaluate();
+		} catch (AssumptionViolatedException e) {
+			eachNotifier.addFailedAssumption(e);
+		} catch (Throwable e) {
+			eachNotifier.addFailure(e);
+		} finally {
+			eachNotifier.fireTestFinished();
+		}
+	}
+	
+	static Description newDescription(FrameworkMethod method, TestClass testClass) {
+		return Description.createTestDescription(testClass.getJavaClass(), method.getName());
+	}
+}

--- a/src/test/java/com/naver2021test/runner/TestBlock.java
+++ b/src/test/java/com/naver2021test/runner/TestBlock.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019 DREAMUS COMPANY.
+ * All right reserved.
+ * This software is the confidential and proprietary information of DREAMUS COMPANY.
+ * You shall not disclose such Confidential Information and
+ * shall use it only in accordance with the terms of the license agreement
+ * you entered into with DREAMUS COMPANY.
+ */
+
+package com.naver2021test.runner;
+
+import org.junit.runner.Description;
+
+/**
+ * {@link TestClassBlock}과 {@link TestMethodBlock}에서 사용하기 위한 기본적인 함수들을 정의한 interface.
+ *
+ * @author M.Ryan (sh.ryan.park@dreamus.io)
+ * @since 2021-05-04
+ */
+public interface TestBlock {
+	
+	/**
+	 * {@link org.junit.runners.model.Statement#evaluate()}와 동일한 interface를 유지하기 위해 추가된 함수.
+	 * 실제 테스트 대상을 수행할 때 사용되는 함수이다.
+	 */
+	void evaluate() throws Throwable;
+	
+	/**
+	 * {@link org.junit.Rule} 등에 의해 {@link Description} 정보를 다루어야 할 일이 있으므로
+	 * 현재 수행되는 TestBlock에 해당하는 Description을 받을 수 있어야 한다.
+	 */
+	Description getDescription();
+}

--- a/src/test/java/com/naver2021test/runner/TestClassBlock.java
+++ b/src/test/java/com/naver2021test/runner/TestClassBlock.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2019 DREAMUS COMPANY.
+ * All right reserved.
+ * This software is the confidential and proprietary information of DREAMUS COMPANY.
+ * You shall not disclose such Confidential Information and
+ * shall use it only in accordance with the terms of the license agreement
+ * you entered into with DREAMUS COMPANY.
+ */
+
+package com.naver2021test.runner;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.internal.runners.model.ReflectiveCallable;
+import org.junit.internal.runners.statements.Fail;
+import org.junit.internal.runners.statements.RunAfters;
+import org.junit.internal.runners.statements.RunBefores;
+import org.junit.rules.RunRules;
+import org.junit.rules.TestRule;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+import org.junit.runners.model.TestClass;
+
+import java.util.List;
+
+/**
+ * {@link org.junit.runners.ParentRunner}에서 테스트 대상을 실행하기 위해 {@link Statement}를 구축하는 과정 중
+ * {@link TestClass}와 관련된 작업을 담당하는 부분으로 {@link TestMethodBlock}과의 계증 구조를 맞추기 위해 분리했다.
+ *
+ * @author M.Ryan (sh.ryan.park@dreamus.io)
+ * @since 2021-05-04
+ */
+public abstract class TestClassBlock implements TestBlock {
+	
+	private final TestClass testClass;
+	
+	public TestClassBlock(TestClass testClass) {
+		this.testClass = testClass;
+	}
+	
+	protected TestClass getTestClass() {
+		return testClass;
+	}
+	
+	
+	protected Object createTest() {
+		try {
+			return new ReflectiveCallable() {
+				@Override
+				protected Object runReflectiveCall() throws Throwable {
+					return testClass.getOnlyConstructor().newInstance();
+				}
+			}.run();
+		} catch (Throwable e) {
+			return new Fail(e);
+		}
+	}
+	
+	
+	protected Statement withBeforeClasses(Statement statement) {
+		List<FrameworkMethod> befores = testClass.getAnnotatedMethods(BeforeClass.class);
+		return befores.isEmpty() ? statement : new RunBefores(statement, befores, null);
+	}
+	
+	
+	protected Statement withAfterClasses(Statement statement) {
+		List<FrameworkMethod> afters = testClass.getAnnotatedMethods(AfterClass.class);
+		return afters.isEmpty() ? statement : new RunAfters(statement, afters, null);
+	}
+	
+	
+	protected Statement withClassRules(Statement statement) {
+		List<TestRule> classRules = classRules(testClass);
+		return classRules.isEmpty() ? statement : new RunRules(statement, classRules, getDescription());
+	}
+	
+	
+	private static List<TestRule> classRules(TestClass testClass) {
+		List<TestRule> result = testClass.getAnnotatedMethodValues(null, ClassRule.class, TestRule.class);
+		result.addAll(testClass.getAnnotatedFieldValues(null, ClassRule.class, TestRule.class));
+		return result;
+	}
+}

--- a/src/test/java/com/naver2021test/runner/TestMethodBlock.java
+++ b/src/test/java/com/naver2021test/runner/TestMethodBlock.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2019 DREAMUS COMPANY.
+ * All right reserved.
+ * This software is the confidential and proprietary information of DREAMUS COMPANY.
+ * You shall not disclose such Confidential Information and
+ * shall use it only in accordance with the terms of the license agreement
+ * you entered into with DREAMUS COMPANY.
+ */
+
+package com.naver2021test.runner;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.internal.runners.statements.ExpectException;
+import org.junit.internal.runners.statements.InvokeMethod;
+import org.junit.internal.runners.statements.RunAfters;
+import org.junit.internal.runners.statements.RunBefores;
+import org.junit.rules.MethodRule;
+import org.junit.rules.RunRules;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+import org.junit.runners.model.TestClass;
+
+import java.util.List;
+
+/**
+ * {@link org.junit.runners.BlockJUnit4ClassRunner}에서 테스트 대상을 실행하기 위해 {@link Statement}를 구축하는 과정을
+ * 복사해 재정리한 코드. 기존 코드가 반드시 {@link org.junit.runner.Runner}를 상속 받아야 하는 구조 때문에
+ * 단일 {@link FrameworkMethod} 만을 테스트 대상으로 처리할 때에는 활용하기가 어려워 분리
+ *
+ * @author M.Ryan (sh.ryan.park@dreamus.io)
+ * @since 2021-05-04
+ */
+public class TestMethodBlock extends TestClassBlock {
+	
+	private final FrameworkMethod method;
+	
+	private final Description description;
+	
+	public TestMethodBlock(TestClass testClass, FrameworkMethod method) {
+		super(testClass);
+		this.method = method;
+		this.description = Description.createTestDescription(testClass.getJavaClass(), method.getName());
+	}
+	
+	
+	@Override
+	public Description getDescription() {
+		return description;
+	}
+	
+	@Override
+	public void evaluate() throws Throwable {
+		methodBlock().evaluate();
+	}
+	
+	
+	private Statement methodBlock() {
+		final Object test = createTest();
+		Statement statement = methodInvoker(method, test);
+		statement = possiblyExpectingExceptions(method, statement);
+		statement = withBefores(test, statement);
+		statement = withAfters(test, statement);
+		statement = withRules(method, test, statement);
+		statement = withBeforeClasses(statement);
+		statement = withAfterClasses(statement);
+		statement = withClassRules(statement);
+		return statement;
+	}
+	
+	
+	protected Statement methodInvoker(final FrameworkMethod method, final Object test) {
+		return new InvokeMethod(method, test);
+	}
+	
+	
+	private Statement possiblyExpectingExceptions(FrameworkMethod method, Statement next) {
+		Test annotation = method.getAnnotation(Test.class);
+		return expectsException(annotation) ? new ExpectException(next, getExpectedException(annotation)) : next;
+	}
+	
+	
+	private Statement withBefores(Object target, Statement statement) {
+		List<FrameworkMethod> befores = getTestClass().getAnnotatedMethods(Before.class);
+		return befores.isEmpty() ? statement : new RunBefores(statement, befores, target);
+	}
+	
+	
+	private Statement withAfters(Object target, Statement statement) {
+		List<FrameworkMethod> afters = getTestClass().getAnnotatedMethods(After.class);
+		return afters.isEmpty() ? statement : new RunAfters(statement, afters, target);
+	}
+	
+	
+	private Statement withRules(FrameworkMethod method, Object target, Statement statement) {
+		List<TestRule> testRules = getTestRules(getTestClass(), target);
+		Statement result = statement;
+		result = withMethodRules(getTestClass(), method, testRules, target, result);
+		result = withTestRules(testRules, result, getDescription());
+		return result;
+	}
+	
+	private static boolean expectsException(Test annotation) {
+		return getExpectedException(annotation) != null;
+	}
+	
+	private static Class<? extends Throwable> getExpectedException(Test annotation) {
+		if (annotation == null || annotation.expected() == Test.None.class) {
+			return null;
+		} else {
+			return annotation.expected();
+		}
+	}
+	
+	
+	private static Statement withMethodRules(TestClass testClass, FrameworkMethod method,
+	                                         List<TestRule> testRules, Object target, Statement result) {
+		for (MethodRule each : getMethodRules(testClass, target)) {
+			//noinspection SuspiciousMethodCalls
+			if (!testRules.contains(each)) {
+				result = each.apply(result, method, target);
+			}
+		}
+		return result;
+	}
+	
+	
+	private static List<MethodRule> getMethodRules(TestClass testClass, Object target) {
+		return rules(testClass, target);
+	}
+	
+	
+	private static List<MethodRule> rules(TestClass testClass, Object target) {
+		List<MethodRule> rules = testClass.getAnnotatedMethodValues(target, Rule.class, MethodRule.class);
+		rules.addAll(testClass.getAnnotatedFieldValues(target, Rule.class, MethodRule.class));
+		return rules;
+	}
+	
+	
+	private static Statement withTestRules(List<TestRule> testRules, Statement statement, Description description) {
+		return testRules.isEmpty() ? statement : new RunRules(statement, testRules, description);
+	}
+	
+	
+	private static List<TestRule> getTestRules(TestClass testClass, Object target) {
+		List<TestRule> result = testClass.getAnnotatedMethodValues(target, Rule.class, TestRule.class);
+		result.addAll(testClass.getAnnotatedFieldValues(target, Rule.class, TestRule.class));
+		return result;
+	}
+	
+}

--- a/src/test/java/com/naver2021test/test/BasicTest.java
+++ b/src/test/java/com/naver2021test/test/BasicTest.java
@@ -1,0 +1,46 @@
+package com.naver2021test.test;
+
+
+import com.naver2021test.runner.Repeat;
+import com.naver2021test.runner.RepeatRunner;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * {@link Repeat} 을 이용하여 지정한 횟수 만큼 동작 하고, 결과과 그룹화 되어 표시되는 지 확인한다
+ *
+ * @author M.Ryan (sh.ryan.park@dreamus.io)
+ * @since 2021-05-02
+ */
+@RunWith(RepeatRunner.class)
+public class BasicTest {
+	
+	@Test
+	public void testNonRepeated() {
+		System.out.println("testNonRepeated");
+	}
+	
+	@Ignore
+	public void testIgnored() {
+		System.out.println("testNonRepeated");
+	}
+	
+	@Repeat(5)
+	@Test
+	public void testMyCode5Times() {
+		System.out.println("testMyCode5Times");
+	}
+	
+	@Repeat(10)
+	@Test
+	public void testMyCode10Times() {
+		System.out.println("testMyCode10Times");
+	}
+	
+	@Repeat(500)
+	@Test
+	public void testMyCode500Times() {
+		System.out.println("testMyCode5Times");
+	}
+}

--- a/src/test/java/com/naver2021test/test/ClassRuleTest.java
+++ b/src/test/java/com/naver2021test/test/ClassRuleTest.java
@@ -1,0 +1,31 @@
+package com.naver2021test.test;
+
+import com.naver2021test.runner.RepeatRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * description
+ *
+ * @author M.Ryan (sh.ryan.park@dreamus.io)
+ * @since 2021-05-05
+ */
+@RunWith(RepeatRunner.class)
+public class ClassRuleTest {
+	@Rule
+	public TestName name = new TestName();
+	
+	@Test
+	public void test_class_rule_name1() {
+		assertEquals("test_class_rule_name1", name.getMethodName());
+	}
+	
+	@Test
+	public void test_class_rule_name2() {
+		assertEquals("test_class_rule_name2", name.getMethodName());
+	}
+}

--- a/src/test/java/com/naver2021test/test/RuleTest.java
+++ b/src/test/java/com/naver2021test/test/RuleTest.java
@@ -1,0 +1,41 @@
+package com.naver2021test.test;
+
+import com.naver2021test.runner.Repeat;
+import com.naver2021test.runner.RepeatRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.core.Is.isA;
+
+/**
+ * {@link RepeatRunner} 사용 시 {@link Rule} annotation 이 정상 동작 하는 지 테스트 한다.
+ *
+ * @author M.Ryan (sh.ryan.park@dreamus.io)
+ * @since 2021-05-05
+ */
+@RunWith(RepeatRunner.class)
+public class RuleTest {
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
+	
+	@Test
+	public void expect_throw_exception() {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectCause(isA(NullPointerException.class));
+		thrown.expectMessage("error message");
+		
+		throw new IllegalArgumentException("error message", new NullPointerException());
+	}
+	
+	@Repeat(5)
+	@Test
+	public void expect_throw_exception_5times() {
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectCause(isA(NullPointerException.class));
+		thrown.expectMessage("error message");
+		
+		throw new IllegalArgumentException("error message", new NullPointerException());
+	}
+}


### PR DESCRIPTION
## `@Repeat`을 이용하여 반복 테스트를 위한 `RepeatRunner` 개발 5e3fed6
- Test 메소드에 `@Repeat`이 존재할 경우 `RepeatRunner.RepeatMethodGroupingRunner` 를 사용하여 반복 및 테스트 결과 그룹화를 처리하고, `@Repeat`이 없는 단일 실행 메소드일 경우 `SimpleMethodRunner`를 이용하여 처리한다.
- `RepeatRunner.RepeatMethodGroupingRunner`는 `Suite`를 확정하여 내부적으로 `Runner` 집합을 가지고 있으며 이를 이용하여 반복 실행 및 그룹화를 처리한다.
- 반복 Method 그룹의 index를 표시하기 위해 `FrameworkMethod`를 확장한 `FrameworkMethodWithIndexed`를 사용하고, `testName` 메소드를 override하여 `indexedTestName`을 이용하여 index가 포함된 테스트 명을 표현한다



## `@RepeatRunner`를 이용한 테스트 작성  599c1c8
- `BasicTest` `@repeat` 가 있는 경우와 없는 경우에 반복 횟수 만큼 실행되는 지 테스트한다
- `RuleTest` `@rule` 을 설정하고 method 단위로 `Rule`이 잘 적용되는 지 테스트한다
- `ClassRuleTes`t `@ClassRule`을 설정하고 전체 테스트 class에 Rule이 잘 적용되는 지 테스트한다
